### PR TITLE
Fix Foreground service app crash.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:name=".App"
         android:theme="@style/AppTheme">
         <service
             android:name=".CountDownTimerService"

--- a/app/src/main/java/gis2018/udacity/pomodoro/MainActivity.java
+++ b/app/src/main/java/gis2018/udacity/pomodoro/MainActivity.java
@@ -1,6 +1,7 @@
 package gis2018.udacity.pomodoro;
 
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
@@ -33,7 +34,11 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         Intent serviceIntent = new Intent(this, CountDownTimerService.class);
         serviceIntent.putExtra("time_period", TIME_PERIOD);
         serviceIntent.putExtra("time_interval", TIME_INTERVAL);
-        startService(serviceIntent);
+
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+            startForegroundService(serviceIntent);
+        else
+            startService(serviceIntent);
     }
 
     @Override


### PR DESCRIPTION
## Description

Fix bug to comply with new Android policy. On API 26 and above `startForegroundService` is called instead of `startService`.

Fixes #17 
## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
