### PR TITLE
Added Java Logic for Work / Break Cycles

### DIFF
--- a/app/src/main/java/gis2018/udacity/pomodoro/CountDownTimerService.java
+++ b/app/src/main/java/gis2018/udacity/pomodoro/CountDownTimerService.java
@@ -13,6 +13,7 @@ import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
 import gis2018.udacity.pomodoro.utils.Utils;
+
 import static gis2018.udacity.pomodoro.utils.Constants.POMODORO;
 
 import static gis2018.udacity.pomodoro.App.CHANNEL_ID;
@@ -69,7 +70,7 @@ public class CountDownTimerService extends Service {
     }
 
     /**
-     * @return a CountDownTimer which ticks every 1 second for a fixed 5 seconds period.
+     * @return a CountDownTimer which ticks every 1 second for given Time period.
      */
     private CountDownTimer countDownTimerBuilder(long TIME_PERIOD, long TIME_INTERVAL,
                                                  final String END_MESSAGE) {
@@ -95,9 +96,19 @@ public class CountDownTimerService extends Service {
             @Override
             public void onFinish() {
                 // Updates and Retrieves new value of WorkSessionCount.
-                if(currentlyRunningServiceType == POMODORO)
+                if (currentlyRunningServiceType == POMODORO) {
                     newWorkSessionCount = Utils.updateWorkSessionCount(preferences, getApplicationContext());
+                    // Getting type of break user should take, and updating type of currently running service
+                    currentlyRunningServiceType = Utils.getTypeOfBreak(preferences, getApplicationContext());
+                } else {
+                    // If last value of currentlyRunningServiceType was SHORT_BREAK or LONG_BREAK then set it back to POMODORO
+                    currentlyRunningServiceType = POMODORO;
+                }
+
                 newWorkSessionCount = preferences.getInt(getString(R.string.work_session_count_key), 0);
+                // Updating value of currentlyRunningServiceType in SharedPreferences.
+                Utils.updateCurrentlyRunningServiceType(preferences, getApplicationContext(), currentlyRunningServiceType);
+
                 Log.v(LOG_TAG, END_MESSAGE);
                 stopSelf();
                 stoppedBroadcastIntent();

--- a/app/src/main/java/gis2018/udacity/pomodoro/utils/Constants.java
+++ b/app/src/main/java/gis2018/udacity/pomodoro/utils/Constants.java
@@ -1,0 +1,9 @@
+package gis2018.udacity.pomodoro.utils;
+
+public class Constants {
+
+    public static int POMODORO = 0;
+    public static int SHORT_BREAK = 1;
+    public static int LONG_BREAK = 2;
+
+}

--- a/app/src/main/java/gis2018/udacity/pomodoro/utils/Utils.java
+++ b/app/src/main/java/gis2018/udacity/pomodoro/utils/Utils.java
@@ -1,0 +1,148 @@
+package gis2018.udacity.pomodoro.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import gis2018.udacity.pomodoro.R;
+
+import static gis2018.udacity.pomodoro.utils.Constants.LONG_BREAK;
+import static gis2018.udacity.pomodoro.utils.Constants.POMODORO;
+import static gis2018.udacity.pomodoro.utils.Constants.SHORT_BREAK;
+
+public class Utils {
+
+    /**
+     * Updates value of WorkSessionCount by 1 and Writes the same to SharedPreferences.
+     *
+     * @param preferences Injected SharedPreferences instance from caller
+     * @param context     Injected Context from caller
+     * @return updated value of WorkSessionCount
+     */
+    public static int updateWorkSessionCount(SharedPreferences preferences, Context context) {
+        // Retrieving value of workSessionCount (Current value of workSessionCount) from SharedPreference.
+        int oldWorkSessionCount = preferences.getInt(context.getString(R.string.work_session_count_key), 0);
+
+        // Updating oldWorkSessionCount by 1.
+        int newWorkSessionCount = ++oldWorkSessionCount;
+
+        // Writing value of workSessionCount after a session is completed (New value of workSessionCount) in SharedPreference.
+        preferences
+                .edit()
+                .putInt(context.getString(R.string.work_session_count_key), newWorkSessionCount)
+                .apply();
+
+        return newWorkSessionCount;
+    }
+
+    /**
+     * Returns type of break, user should take according to value of workSessionCount
+     *
+     * @param preferences Injected SharedPreferences instance from caller
+     * @param context     Injected Context from caller
+     * @return type of break, user should take
+     */
+    public static int getTypeOfBreak(SharedPreferences preferences, Context context) {
+        int currentWorkSessionCount = preferences.getInt(context.getString(R.string.work_session_count_key), 0);
+        if (currentWorkSessionCount % 4 == 0)
+            return LONG_BREAK;
+        return SHORT_BREAK;
+    }
+
+    /**
+     * Writes new value for currentlyRunningService in SharedPreferences.
+     * Value of currentlyRunningService determines values for textOn & textOff of ToggleButton in MainActivity.
+     *
+     * @param preferences                 Injected SharedPreferences instance from caller
+     * @param context                     Injected Context from caller
+     * @param currentlyRunningServiceType can be POMODORO, SHORT_BREAK or LONG_BREAK
+     */
+    public static void updateCurrentlyRunningServiceType(SharedPreferences preferences, Context context, int currentlyRunningServiceType) {
+        preferences
+                .edit()
+                .putInt(context.getString(R.string.currently_running_service_type_key), currentlyRunningServiceType)
+                .apply();
+    }
+
+    /**
+     * @param preferences Injected SharedPreferences instance from caller
+     * @param context     Injected Context from caller
+     * @return current value of currentlyRunningService from SharedPreferences.
+     */
+    public static int retrieveCurrentlyRunningServiceType(SharedPreferences preferences, Context context) {
+        return preferences.getInt(context.getString(R.string.currently_running_service_type_key), 0);
+    }
+
+    /**
+     * Retrieving current value of Duration for POMODORO, SHORT_BREAK and LONG_BREAK from SharedPreferences.
+     *
+     * @param preferences                 Injected SharedPreferences instance from caller
+     * @param context                     Injected Context from caller
+     * @param currentlyRunningServiceType current value of currentlyRunningService (Can be POMODORO, SHORT_BREAK, or LONG_BREAK).
+     * @return duration of CountDown for a service in milliSeconds according to value of currentlyRunningServiceType.
+     */
+    public static long getCurrentDurationPreferenceOf(SharedPreferences preferences, Context context, int currentlyRunningServiceType) {
+        if (currentlyRunningServiceType == POMODORO) {
+            // Current value of work duration stored in shared-preference
+            int currentWorkDurationPreference = preferences.getInt(context.getString(R.string.work_duration_key), 1);
+
+            // Switch case to return appropriate minute value of work duration according value stored in shared-preference.
+            switch (currentWorkDurationPreference) {
+                case 0:
+                    return 10 * 1000; // 20 minutes
+                case 1:
+                    return 25 * 60000; // 25 minutes
+                case 2:
+                    return 30 * 60000; // 30 minutes
+                case 3:
+                    return 40 * 60000; // 40 minutes
+                case 4:
+                    return 55 * 60000; // 55 minutes
+            }
+        } else if (currentlyRunningServiceType == SHORT_BREAK) {
+            // Current value of short-break duration stored in shared-preference
+            int currentShortBreakDurationPreference = preferences.getInt(context.getString(R.string.short_break_duration_key), 1);
+
+            // Switch case to return appropriate minute value of short-break duration according value stored in shared-preference.
+            switch (currentShortBreakDurationPreference) {
+                case 0:
+                    return 1 * 3000; // 3 minutes
+                case 1:
+                    return 5 * 60000; // 5 minutes
+                case 2:
+                    return 10 * 60000; // 10 minutes
+                case 3:
+                    return 15 * 60000; // 15 minutes
+            }
+        } else if (currentlyRunningServiceType == LONG_BREAK) {
+            // Current value of long-break duration stored in shared-preference
+            int currentLongBreakDurationPreference = preferences.getInt(context.getString(R.string.long_break_duration_key), 1);
+
+            // Switch case to return appropriate minute value of long-break duration according value stored in shared-preference.
+            switch (currentLongBreakDurationPreference) {
+                case 0:
+                    return 2 * 3000; // 10 minutes
+                case 1:
+                    return 15 * 60000; // 15 minutes
+                case 2:
+                    return 20 * 60000; // 20 minutes
+                case 3:
+                    return 25 * 60000; // 25 minutes
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * @param duration of currentlyRunningService (CountDown value) in milliSeconds
+     * @return duration in mm:ss format from duration value in milliSeconds.
+     */
+    public static String getCurrentDurationPreferenceStringFor(long duration) {
+        // https://stackoverflow.com/a/41589025/8411356
+        return String.format(Locale.getDefault(), "%02d:%02d",
+                TimeUnit.MILLISECONDS.toMinutes(duration) % 60,
+                TimeUnit.MILLISECONDS.toSeconds(duration) % 60);
+    }
+}

--- a/app/src/main/java/gis2018/udacity/pomodoro/utils/Utils.java
+++ b/app/src/main/java/gis2018/udacity/pomodoro/utils/Utils.java
@@ -91,7 +91,7 @@ public class Utils {
             // Switch case to return appropriate minute value of work duration according value stored in shared-preference.
             switch (currentWorkDurationPreference) {
                 case 0:
-                    return 10 * 1000; // 20 minutes
+                    return 20 * 60000; // 20 minutes
                 case 1:
                     return 25 * 60000; // 25 minutes
                 case 2:
@@ -108,7 +108,7 @@ public class Utils {
             // Switch case to return appropriate minute value of short-break duration according value stored in shared-preference.
             switch (currentShortBreakDurationPreference) {
                 case 0:
-                    return 1 * 3000; // 3 minutes
+                    return 3 * 60000; // 3 minutes
                 case 1:
                     return 5 * 60000; // 5 minutes
                 case 2:
@@ -123,7 +123,7 @@ public class Utils {
             // Switch case to return appropriate minute value of long-break duration according value stored in shared-preference.
             switch (currentLongBreakDurationPreference) {
                 case 0:
-                    return 2 * 3000; // 10 minutes
+                    return 10 * 60000; // 10 minutes
                 case 1:
                     return 15 * 60000; // 15 minutes
                 case 2:

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -49,7 +49,7 @@
                 android:layout_marginTop="8dp"
                 android:layout_marginEnd="8dp"
                 android:layout_marginBottom="8dp"
-                android:text="Current Task"
+                android:text="@string/current_task"
                 android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
             <Button
@@ -64,7 +64,7 @@
                 android:layout_marginTop="8dp"
                 android:layout_marginEnd="8dp"
                 android:layout_marginBottom="8dp"
-                android:text="Change"
+                android:text="@string/change_task"
                 android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
             <TextView
@@ -77,7 +77,7 @@
                 android:layout_marginTop="8dp"
                 android:layout_marginEnd="8dp"
                 android:layout_marginBottom="8dp"
-                android:text="Task 1"
+                android:text="@string/task_name"
                 android:textAppearance="@style/TextAppearance.AppCompat.Large"
                 android:textStyle="bold" />
 
@@ -90,7 +90,7 @@
                 android:layout_marginTop="8dp"
                 android:layout_marginEnd="8dp"
                 android:layout_marginBottom="8dp"
-                android:text="Work sessions completed"
+                android:text="@string/work_sessions_completed"
                 android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
             <TextView
@@ -113,7 +113,7 @@
     </android.support.v7.widget.CardView>
 
     <ImageView
-        android:id="@+id/finish_button_main"
+        android:id="@+id/finish_imageview_main"
         android:layout_width="117dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
@@ -132,12 +132,12 @@
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="8dp"
-        android:textOff="Start"
-        android:textOn="Cancel"
+        android:textOff="@string/start_pomodoro"
+        android:textOn="@string/cancel_pomodoro"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/settings_imageview_main"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@id/finish_button_main" />
+        app:layout_constraintStart_toEndOf="@id/finish_imageview_main" />
 
     <ImageView
         android:id="@+id/settings_imageview_main"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,18 @@
         <item>20 minutes</item>
         <item>25 minutes</item>
     </string-array>
+
+    <string name="current_task">Current Task</string>
+    <string name="change_task">Change</string>
+    <string name="task_name">Task 1</string>
+    <string name="work_sessions_completed">Work sessions completed</string>
     <string name="complete_imageview_content_desc">Complete Image</string>
     <string name="settings_imageview_content_desc">Settings Image</string>
+    <string name="start_pomodoro">Start Pomodoro</string>
+    <string name="cancel_pomodoro">Cancel Pomodoro</string>
+    <string name="start_short_break">Start Short Break</string>
+    <string name="skip_short_break">Skip Short Break</string>
+    <string name="start_long_break">Start Long Break</string>
+    <string name="skip_long_break">Skip Long Break</string>
+    <string name="currently_running_service_type_key">CURRENTLY_RUNNING_SERVICE_TYPE</string>
 </resources>


### PR DESCRIPTION
## Description

- Added code to change state of toggleButton to handle all states in `MainActivity.java`
- Added code to allow user to take a break after a work-session is completed in `MainActivity.java`
- Added code that prevents counting of cancelled work-sessions in `MainActivity.java`
- Added code that counts number of completed work-sessions by clicking _Complete_ 
- Added a new Java Package *Utils* and added **2 new** files.
    - `Utils.java` contains several utility and helper methods used by `MainActivity.java` and `CountDownTimerService.java`
    - `Constants.java` contains 3 contants values used by `MainActivity.java` and `CountDownTimerService.java`

## [Demo Video](https://vimeo.com/300039743)

For Demo, following values are used for CountDownTimer

- For *Pomodoro* (Work-Session) - **10** seconds.
- For *Short-Break* - **3** seconds.
- For *Long-Break* - **6** seconds.

Fixes #21 #24 #26

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
