### PR TITLE
Added Java Logic for Alert Dialog

### DIFF
--- a/app/src/main/res/layout/layout_alert_dialog.xml
+++ b/app/src/main/res/layout/layout_alert_dialog.xml
@@ -8,39 +8,45 @@
 
     <TextView
         android:id="@+id/alert_title"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginRight="16dp"
+        android:gravity="center"
+        android:text="@string/pomodoro_completion_alert_message"
         android:textColor="@android:color/black"
-        android:textSize="18sp"
-        tools:text="Message" />
+        android:textSize="20sp" />
 
     <Button
         android:id="@+id/start_break"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="64dp"
-        android:layout_marginTop="4dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginRight="16dp"
         android:textAppearance="?android:attr/textAppearanceLarge"
         tools:text="Start Break" />
 
     <Button
         android:id="@+id/start_other_break"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="54dp"
-        android:layout_marginTop="4dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginRight="16dp"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textColor="@android:color/black"
         tools:text="Start Other Break" />
 
     <Button
         android:id="@+id/skip_break"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="44dp"
-        android:layout_marginTop="4dp"
-        android:layout_marginBottom="8dp"
+        android:layout_margin="16dp"
         android:background="@android:color/transparent"
+        android:text="@string/skip_break"
         android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="@android:color/black"
-        tools:text="Skip Break" />
+        android:textColor="@android:color/black" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,5 +39,7 @@
     <string name="skip_short_break">Skip Short Break</string>
     <string name="start_long_break">Start Long Break</string>
     <string name="skip_long_break">Skip Long Break</string>
+    <string name="skip_break">Skip Break</string>
     <string name="currently_running_service_type_key">CURRENTLY_RUNNING_SERVICE_TYPE</string>
+    <string name="pomodoro_completion_alert_message">Congrats, Pomodoro is over.\n\nIt\'s time for a break.</string>
 </resources>


### PR DESCRIPTION
## Description

- Alert Popups at the end of every **Work-Session**.
- Alerts are also shown when value of `currentlyRunningServiceType` is either `SHORT_BREAK` or `LONG_BREAK` and user **closes the app** then **come backs** or **restarts the app**, after a _Work-Session_ is over. (Check the video you'll get the idea)
- Large Button's text is determined based on usual method, that is after every _Work-Session_ it'll be **Start Short Break**, and after every 4 _Work-Sessions_ it'll be **Start Long Break**.
- Medium Button's text is determined based on text of _Large Button_, so if current text of _Large Button_ is **Start Short Break** then text of _Medium Button_ will be **Start Long Break** and vice versa.
- Skip Button, skips usual break and set state to **Pomodoro**.

## [Demo Video](https://vimeo.com/300627482)
For Demo, following values are used for CountDownTimer

For _Pomodoro_ (Work-Session) - **10** seconds.
For _Short-Break_ - **6** seconds.
For _Long-Break_ - **8** seconds.

Fixes #39

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
